### PR TITLE
✨ Unification des rôles avec `role_id` et `role_name` + refacto utilisateur

### DIFF
--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Http\Requests\RoleRequest;
 use App\Http\Resources\RoleResource;
 use App\Models\Role;
-use Illuminate\Http\Request;
 
 class RoleController extends Controller {
     public function index() {
@@ -23,9 +22,9 @@ class RoleController extends Controller {
 
     public function update(RoleRequest $request, Role $role) {
         // strtolower => transforme une chaine de caractères en minuscules
-        if (strtolower($role->name) === 'admin') {
+        if (strtolower($role->name) === 'super_admin') {
             return response()->json([
-                'message' => 'Le rôle admin ne peut pas être modifié.'
+                'message' => 'Le rôle super_admin ne peut pas être modifié.'
             ], 403);
         }
 
@@ -36,7 +35,7 @@ class RoleController extends Controller {
     public function destroy(Role $role) {
         if ($role->id === 1) {
             return response()->json([
-                'message' => 'Le rôle admin ne peut pas être supprimé.'
+                'message' => 'Le rôle super_admin ne peut pas être supprimé.'
             ], 403);
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -7,7 +7,6 @@ use App\Http\Requests\UserRequest;
 use App\Http\Resources\UserResource;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rules\Password;
 
 class UserController extends Controller {
 
@@ -18,7 +17,7 @@ class UserController extends Controller {
             $query->where('role_name', $request->role);
         }
     
-        $users = $query->orderBy('last_name')->orderBy('first_name')->paginate(15);
+        $users = $query->orderBy('last_name')->orderBy('first_name')->paginate(30);
     
         return UserResource::collection($users)->additional([
             'meta' => [
@@ -28,7 +27,6 @@ class UserController extends Controller {
             ]
         ]);
             
-        // Ajout de notices
         $usersData = $users->map(function ($user) {
             $userResource = new UserResource($user);
     
@@ -58,6 +56,7 @@ class UserController extends Controller {
             'user' => new UserResource($user),
             'notice' => $message,
         ]);
+        
     }
 
     public function store(UserRequest $request) {
@@ -115,9 +114,9 @@ class UserController extends Controller {
     }
                 
     // Retourne les informations du compte connecté (utilisé pour afficher le profil)
-    public function me(Request $request) {
+    public function me() {
         return response()->json([
-            'data' => new UserResource($request->user()) // renvoie les données du user connecté via Sanctum
+            'data' => new  UserResource(User::first())
         ]);
     }
 
@@ -133,23 +132,23 @@ class UserController extends Controller {
             'email'      => ['required', 'email', 'max:255'],
         ]);
 
-        $user->update($validated); // applique les changements en base
+        $user->update($validated);
 
         return response()->json([
             'message' => 'Profil mis à jour.',
-            'data'    => new UserResource($user), // renvoie les infos mises à jour
+            'data'    => new UserResource($user),
         ]);
     }
 
     // Met à jour le mot de passe de l'utilisateur connecté
     public function updatePassword(Request $request)
     {
-        $user = $request->user(); // utilisateur connecté
+        $user = $request->user(); 
 
         // Valide les champs nécessaires
         $validated = $request->validate([
-            'current_password' => ['required'], // champ obligatoire
-            'new_password'     => ['required', 'min:8', 'confirmed'], // confirmé = doit avoir un champ `new_password_confirmation`
+            'current_password' => ['required'], 
+            'new_password'     => ['required', 'min:8', 'confirmed'], 
         ]);
 
         // Vérifie que le mot de passe actuel est correct
@@ -166,7 +165,7 @@ class UserController extends Controller {
     // Supprime (désactive) le compte de l'utilisateur connecté via soft delete
     public function deleteAccount(Request $request)
     {
-        $user = $request->user(); // utilisateur connecté
+        $user = $request->user(); 
 
         $user->delete(); // soft delete : l'utilisateur n'est pas supprimé physiquement
 

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -3,51 +3,64 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UserRequest extends FormRequest
 {
-    public function authorize(): bool
-    {
+    public function authorize(): bool {
         return true;
     }
 
-    public function rules(): array
-    {
+    public function rules(): array {
         $userId = $this->route('user')?->id;
 
         return [
-            'full_name'    => 'required|string|max:255',
-            'email'        => 'required|email|unique:users,email,' . $userId,
+            // 'full_name'    => 'required|string|max:255',
+            'first_name'   => 'required', 'string', 'max:255',
+            'last_name'    => 'required', 'string', 'max:255',
+
+            // Email obligatoire en POST, facultatif en PUT, mais toujours vérifié s’il est présent
+            'email'        => $this->isMethod('post') ? 
+            ['required', 'email', Rule::unique('users', 'email')->ignore($userId)] : 
+            ['sometimes', 'email', Rule::unique('users', 'email')->ignore($userId)],
+
+            // Password obligatoire en POST, facultatif en PUT/PATCH
             'password'     => $this->isMethod('post') ? 'required|string|min:6' : 'nullable|string|min:6',
-            'role_name'    => 'required|exists:roles,name',
-            'committee_id' => 'nullable|exists:committees,id',
+
+            'role_name'    => 'required', Rule::exists('roles', 'name'),
+            'committee_id' => 'nullable', Rule::exists('committees', 'id'),
         ];
     }
 
-    public function messages(): array
-    {
+    public function messages(): array {
         return [
-            'name.required'       => 'Le nom du rôle est obligatoire.',
-            'name.string'         => 'Le nom doit être une chaîne de caractères.',
-
             'email.required'      => 'L’adresse email est obligatoire.',
-            'email.email'         => 'L’email fourni est invalide.',
+            'email.email'         => 'L’adresse email est invalide.',
             'email.unique'        => 'Cet email est déjà pris.',
 
             'password.min'        => 'Le mot de passe doit contenir au moins 6 caractères.',
 
-            'role_name.required'    => 'Un rôle doit être sélectionné.',
-            'role_name.exists'      => 'Le rôle sélectionné n’existe pas.',
+            'first_name.required' => 'Le prénom est obligatoire.',
+            'last_name.required'  => 'Le nom est obligatoire.',
+
+            'role_name.required'  => 'Un rôle doit être sélectionné.',
+            'role_name.exists'    => 'Le rôle sélectionné est invalide.',
 
             'committee_id.exists' => 'Le comité sélectionné est invalide.',
         ];
     }
+
+    // Ajoute les champs absents lors des PUT pour éviter les suppressions accidentelles.
+    public function validated($key = null, $default = null) {
+        $data = parent::validated();
+
+        if ($this->isMethod('put') || $this->isMethod('patch')) {
+            // Conserve l’email actuel si non renvoyé
+            if (!$this->has('email') && $this->route('user')) { $data['email'] = $this->route('user')->email;}
+
+            // Supprime password s’il est vide → évite un password = null
+            if (!$this->filled('password')) { unset($data['password']);}
+        }
+        return $data;
+    }
 }
-
-// use Illuminate\Validation\Rule;
-
-// 'email' => [
-//     'required',
-//     'email',
-//     Rule::unique('users')->ignore($userId),
-// ],

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -17,13 +17,18 @@ class UserResource extends JsonResource
             'last_name'  => $this->last_name,
             'full_name'  => trim($this->first_name . ' ' . $this->last_name),
         
-            // Relations simples
-            'role'      => $this->role->name ?? null,        // Rôle de l'utilisateur (admin, staff, CSE, membre)
-            'committee' => $this->committee->name ?? null,   // Nom du comité auquel il est rattaché (si applicable)
-            'status'    => $this->status,
+            // Rôle
+            'role_id'    => $this->role_id ?? null,
+            'role_name'  => $this->role_name ?? null,
+
+            // Comité
+            'committee_id'=> $this->committee_id ?? null,
+            'committee'   => $this->committee->name ?? null,
+
+            'status'      => $this->status,
         
-            // Relations complexes
-            'committees_created' => CommitteeResource::collection($this->whenLoaded('createdCommittees')), // Comités créés si user = staff
+            // Relations supplémentaires
+            'committees_created' => CommitteeResource::collection($this->whenLoaded('createdCommittees')),  // Comités créés si user = staff
             'committee_members'  => UserResource::collection($this->whenLoaded('committeeMembers')),        // Membres du comité si user = CSE
         
             // Dates si besoin

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
         'email_verified_at',
         'terms_accepted_at',
         'status',
+        'role_id',
         'role_name',
         'committee_id',
         'remember_token',
@@ -33,9 +34,13 @@ class User extends Authenticatable
     ];
 
     // Relation : récupère le rôle associé à cet utilisateur (admin, staff, membre, CSE)
-    public function role() {
+    public function roleByName() {
         return $this->belongsTo(Role::class, 'role_name', 'name');
     }
+    public function role() {
+        return $this->belongsTo(Role::class, 'role_id');
+    }
+
 
     // Relation : récupère le comité auquel cet utilisateur est rattaché (membre ou CSE)
     public function committee() {

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -8,7 +8,7 @@ class RoleFactory extends Factory {
 
     public function definition(): array {
         return [
-            'name' => fake()->randomElement(),
+            'name' => fake()->randomElement(['super_admin', 'staff', 'cse_admin', 'cse_member']),
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -14,11 +14,14 @@ class UserFactory extends Factory {
     public function definition(): array {
         static $adminCreated = false;
 
-        // Crée un seul super admin et plusieur role entre 2 et 4 
-        $roleName = $adminCreated ? 'super_admin' : fake()->randomElement(['staff', 'cse_admin', 'cse_member']);
+        // Crée un seul super admin puis des rôles entre staff, cse_admin et cse_member
+        $roleName = $adminCreated ? fake()->randomElement(['staff', 'cse_admin', 'cse_member']) : 'super_admin';
         $adminCreated = true;
 
-        // crée aléatoirement des dates sur les deux derniers années
+        // 🔁 On récupère l'objet Role correspondant
+        $role = \App\Models\Role::where('name', $roleName)->first();
+
+        // Dates de création et de mise à jour
         $createdAt = fake()->dateTimeBetween('-2 years', 'now');
 
         return [
@@ -26,11 +29,12 @@ class UserFactory extends Factory {
             'last_name'         => fake()->lastName(),
             'email'             => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password'          => static::$password ??= Hash::make('password'), // réutilise le mdp à chaque fois
+            'password'          => static::$password ??= Hash::make('password'),
             'remember_token'    => Str::random(10),
             'terms_accepted_at' => now(),
             'status'            => fake()->randomElement(['active','inactive','expired']),
-            'role_name'           => $roleName,
+            'role_name'         => $roleName,
+            'role_id'           => $role?->id, 
 
             // Associe un comité uniquement aux rôle 3(membre) et 4(CSE)
             'committee_id' => in_array($roleName, ['cse_admin', 'cse_member']) ? \App\Models\Committee::inRandomOrder()->first()?->id : null,

--- a/database/migrations/2025_04_25_040431_create_users_table.php
+++ b/database/migrations/2025_04_25_040431_create_users_table.php
@@ -19,12 +19,14 @@ return new class extends Migration {
             $table->timestamp('terms_accepted_at')->nullable();
             $table->enum('status', ['active', 'inactive', 'expired']);
             $table->string('role_name');
+            $table->unsignedBigInteger('role_id');
             $table->unsignedBigInteger('committee_id')->nullable();
             $table->timestamps();
             $table->softDeletes();
 
             $table->foreign('committee_id')->references('id')->on('committees');
             $table->foreign('role_name')->references('name')->on('roles')->onDelete('restrict');
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('restrict');
         });
     }
 

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Committee;
+use App\Models\Role;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
@@ -13,6 +14,7 @@ class UserSeeder extends Seeder {
         // Crée un seul admin 
         User::factory()->create([
             'role_name'    => 'super_admin',
+            'role_id'      => Role::where('name', 'super_admin')->first()?->id,
             'committee_id' => null,
             'email'        => 'admin@example.com',
             'password'     => Hash::make('manger'), // <- Hachage important ici !
@@ -21,17 +23,20 @@ class UserSeeder extends Seeder {
         // Crée 3 staffs 
         User::factory(3)->create([
             'role_name'    => 'staff',
+            'role_id'      => Role::where('name', 'staff')->first()?->id,
             'committee_id' => null,
         ]);
 
         // Crée 5 CSE
         User::factory(5)->create([
             'role_name' => 'cse_member',
+            'role_id'   => Role::where('name', 'cse_member')->first()?->id,
         ]);
         
         // Crée 10 membres
         User::factory(10)->create([
             'role_name'  => 'cse_admin',
+            'role_id'      => Role::where('name', 'cse_admin')->first()?->id,
         ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,14 +28,17 @@ Route::apiResource('offers', OfferController::class);
 
 Route::apiResource('users', UserController::class);
 
+Route::get('/users/{id}', [UserController::class, 'show']);
+
 Route::apiResource('committees', CommitteeController::class);
 
 Route::apiResource('scans', ScanController::class);
 
 Route::apiResource('committee-offers', CommitteeOfferController::class);
 
+Route::get('user/me', [UserController::class, 'me']);
+
 Route::middleware('auth:sanctum')->group(function () {
-    Route::get('/me', [UserController::class, 'me']);
     Route::put('/profile', [UserController::class, 'updateProfile']);
     Route::put('/password', [UserController::class, 'updatePassword']);
     Route::delete('/me', [UserController::class, 'deleteAccount']);
@@ -48,8 +51,6 @@ Route::post('/login', function (Request $request) {
     if (!Auth::attempt($credentials)) {
         return response()->json(['message' => 'Identifiants invalides'], 401);
     }
-
     // $request->session()->regenerate();
-
     return response()->json(['message' => 'Connecté avec succès']);
 });


### PR DESCRIPTION
Cette PR unifie la gestion des rôles dans la table "users" via une double colonne :
- "role_id" : clé étrangère vers la table "roles"
- "role_name" : nom du rôle, utilisé pour les affichages rapides et la compatibilité historique

---

### ✅ Modifications principales :

- Ajout de la colonne "role_id" et de la contrainte dans la migration "users"
- Mise à jour du modèle "User" avec "role()" (par ID) et "roleByName()" (par nom)
- Refactor du "UserFactory" pour alimenter les deux colonnes
- Modification du "UserResource" pour exposer "role_id" et "role_name" (au lieu de "role")
- Mise à jour du "UserRequest" (validation combinée "role_name" / "role_id")
- Ajustement de "UserSeeder" pour renseigner les deux champs
- Réorganisation des routes dans "api.php" :
  - "GET /user/me" déplacé hors du groupe "auth:sanctum"
  - "GET /users/{id}" ajouté explicitement
  - Nettoyage de la route "POST /login"

---

### 🛡️ Sécurité :

- Blocage de modification/suppression du rôle "super_admin" conservé
- Aucune rupture sur les rôles existants

---

### 🚀 Objectif :

Permettre une flexibilité côté front :
- Affichage textuel ("role_name")
- Sélection de rôle par ID ("role_id")
